### PR TITLE
Update genai to visual assertion naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Create a temporary email address, send a test email, and open it to verify that 
 
 https://github.com/mablhq/mabl-playwright-integrations/blob/10ad92514d993016a479f39b9e2063c3dc39eaf9/tests/mabl-demos/email.spec.ts#L8-L22
 
-### GenAI testing
-Evaluate the state of the page `https://www.mabl.com` with a [GenAI Assertion](https://help.mabl.com/hc/articles/28810650854292):
+### AI-powered validations
+Evaluate the state of the page `https://www.mabl.com` with a [visual assertion](https://help.mabl.com/hc/articles/28810650854292):
 
 https://github.com/mablhq/mabl-playwright-integrations/blob/10ad92514d993016a479f39b9e2063c3dc39eaf9/tests/mabl-demos/genAi.spec.ts#L7-L14
 

--- a/tests/freshbooks/freeshbooks.spec.ts
+++ b/tests/freshbooks/freeshbooks.spec.ts
@@ -45,6 +45,7 @@ test('Create an invoice', async ({context, page, mabl}) => {
   // use the mabl tools to open the file in a new Page 
   await mabl.openPdfFile(`./downloads/${invoiceNumber}.pdf`, pageForPdf);
 
+  // Visual assertions are known as "GenAI Assertions" in the evaluateGenAiAssertion function.
   const aiResult = await mabl.evaluateGenAiAssertion(
     pageForPdf, 
     `

--- a/tests/mabl-demos/genAi.spec.ts
+++ b/tests/mabl-demos/genAi.spec.ts
@@ -13,3 +13,23 @@ test('Evaluate a GenAI assertion to validate the state of a page', async ({
   console.log(result.explanation);
   expect(result.success).toBe(true);
 });
+
+// Enable "GenAI file downloads" in Labs before using this test
+test('Evaluate a GenAI assertion with downloaded CSV file', async ({page, mabl}) => {
+  await page.goto('https://sandbox.mabl.com/downloads-pdfs');
+
+  // Wait for the download button and trigger download
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByText('Download CSV').click();
+  const download = await downloadPromise;
+
+  const result = await mabl.evaluateGenAiAssertionInFile(
+    page,
+    'Outdoor Patio Chair is in stock',
+    download,
+  );
+
+  console.log('GEN AI EXPLANATION FOR CSV');
+  console.log(result.explanation);
+  expect(result.success).toBe(true);
+});

--- a/tests/mabl-demos/genAi.spec.ts
+++ b/tests/mabl-demos/genAi.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../fixtures";
 
+// Visual assertions are known as "GenAI Assertions" in the evaluateGenAiAssertion function.
 test('Evaluate a GenAI assertion to validate the state of a page', async ({
   page,
   mabl,


### PR DESCRIPTION
Making this PR to keep our naming up-to-date for Playwright tools, since "GenAI Assertions" are now called "visual assertions"

Included:

- Updated naming in the README.md
- Added comments to evaluateGenAIAssertion function explaining that visual assertions are the same thing as GenAI Assertions
 
Not included:

- Did not rename function calls, test names, filenames, or anything related to download assertions (TBD)